### PR TITLE
Fix hero typo

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -136,7 +136,7 @@ params:
     intro: "Hi, my name is"
     title: "Alexander."
     subtitle: "I build things for people"
-    content: "A passionate softare developer. I tend to make use of modern technologies to build things that look great, feel fantastic, and function correctly."
+    content: "A passionate software developer. I tend to make use of modern technologies to build things that look great, feel fantastic, and function correctly."
     image: /images/image.jpg
     bottomImage:
       enable: true


### PR DESCRIPTION
## Summary
- fix hero description typo in `hugo.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fc9f945448321a3309d44afebacda