### PR TITLE
Add blog and gallery content

### DIFF
--- a/content/blogs/_index.md
+++ b/content/blogs/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Blog"
+description: "Stories about the projects I'm building, the lessons I am learning, and the ideas that keep me curious."
+---
+
+Welcome to the journal where I document my experiments in design, development, and the spaces in-between. Each article dives into the decisions, tools, and processes that shape my work.

--- a/content/blogs/automating-qa-workflows.md
+++ b/content/blogs/automating-qa-workflows.md
@@ -1,0 +1,29 @@
+---
+title: "Automating QA Workflows"
+date: 2024-03-02
+draft: false
+description: "Lessons from introducing lightweight automation inside a gas infrastructure company."
+author: "Alexander Büchler"
+tags:
+  - Automation
+  - Process Design
+  - Excel VBA
+image: "https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80"
+toc: true
+---
+
+During my time at GASCADE I was confronted with reams of hazardous substance documentation that had to be updated every time regulations shifted. The team did heroic manual work, but the process took days and inevitably introduced errors. Rather than mandate a new tool, I focused on augmenting the existing Excel-based workflow.
+
+## Listening first
+
+Job shadowing revealed dozens of tiny frictions: copy-pasting chemical IDs from PDF tables, forgetting to update reference sheets, and spending hours compiling reports for audits. I collected each pain point and grouped them into automation candidates.
+
+## Prototyping in the tools people already use
+
+I built the first helper in plain VBA. It scraped regulatory updates, highlighted changes, and produced a diff report directly inside the workbook. Because the script mirrored the team's manual checklist, trust came quickly and adoption was painless.
+
+### The ripple effects
+
+Once colleagues saw the time savings, they requested additional automations: automatic email summaries, validation prompts, and templated audit exports. Over six months the average update cycle dropped from three days to less than one.
+
+The experience taught me that automation is about empathy as much as code. By respecting existing expertise and workflows, we created space for the team to focus on higher-value work.

--- a/content/blogs/fuseki-forge-go.md
+++ b/content/blogs/fuseki-forge-go.md
@@ -1,0 +1,29 @@
+---
+title: "Designing Fuseki Forge Go"
+date: 2024-05-12
+draft: false
+description: "How I translated the strategy of Go into a calm, focused mobile experience."
+author: "Alexander Büchler"
+tags:
+  - Product Design
+  - SwiftUI
+  - UX Research
+image: "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=1200&q=80"
+toc: true
+---
+
+When I started Fuseki Forge Go, my goal was to design a tool that treated the ancient game of Go with the same respect modern chess apps give to their players. Most Go apps feel cluttered, visually noisy, or stuck in desktop paradigms. I wanted to blend the meditative pace of the game with a crisp, focused interface.
+
+## Mapping the journey
+
+I began by interviewing a handful of club players about their daily routines. Their feedback revealed that most people review games on the subway or a sofa—places where one-handed navigation matters. That insight shaped the entire layout: primary controls sit at thumb height and complex options hide behind contextual menus.
+
+### Prioritising states over screens
+
+Rather than creating separate screens for playing, reviewing, and learning, I designed one adaptable board component. It reacts to context—showing review tools when you're replaying a match or hint options when you're practising life-and-death problems. This kept the codebase leaner and gave players a consistent experience.
+
+## Crafting a calming palette
+
+To support focus I borrowed colours from traditional Go stones: soft slate for the background, warm off-white for points of interaction, and a single highlight colour that only appears on critical actions. Paired with haptic feedback and subtle animations, the app feels responsive without being distracting.
+
+The project is still evolving, but these foundations have already made playtests smoother and more engaging. Next on the roadmap is integrating SGF import/export so players can jump between the app and their favourite desktop tools.

--- a/content/blogs/learning-through-prototyping.md
+++ b/content/blogs/learning-through-prototyping.md
@@ -1,0 +1,29 @@
+---
+title: "What Rapid Prototyping Teaches Me"
+date: 2023-11-18
+draft: false
+description: "Why I build quick experiments before committing to full productions."
+author: "Alexander Büchler"
+tags:
+  - Prototyping
+  - Game Design
+  - Learning
+image: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+toc: true
+---
+
+I spent my game design studies prototyping relentlessly. The habit stuck with me, and today I still start projects with tiny experiments rather than grand roadmaps. Rapid prototyping is my favourite way to learn because it compresses the feedback loop between idea and insight.
+
+## Start ugly on purpose
+
+My first prototypes are intentionally rough. I assemble off-the-shelf components, grey-box the visuals, and focus entirely on the interaction I want to evaluate. By avoiding polish, I stay open to radical changes and avoid falling in love with the wrong solution.
+
+## Invite critique early
+
+Once something clicks, I put it in front of collaborators—even if it's half broken. Their questions often reveal hidden assumptions about onboarding, failure states, or accessibility that I hadn't considered.
+
+## Ship the learnings forward
+
+The best part about prototypes is that they rarely go to waste. Even when an idea gets shelved, the insights fuel the next iteration. I reuse snippets of code, interaction patterns, and documentation templates across projects, building a personal toolkit that gets sharper with every attempt.
+
+Prototyping keeps me honest, curious, and unafraid to start over.

--- a/content/gallery.md
+++ b/content/gallery.md
@@ -1,0 +1,24 @@
+---
+title: "Visual Notes"
+date: 2024-05-20
+draft: false
+description: "A curated peek behind the scenes of recent projects, travels, and the textures that inspire my work."
+layout: "gallery"
+galleryImages:
+  - src: "https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=1200&q=80"
+    title: "Sketching interface flows"
+  - src: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
+    title: "Morning light in Berlin"
+  - src: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+    title: "Playtesting in progress"
+  - src: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80"
+    title: "Textures for UI moodboards"
+  - src: "https://images.unsplash.com/photo-1500534623283-312aade485b7?auto=format&fit=crop&w=1200&q=80"
+    title: "Weekend escape"
+  - src: "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1200&q=80"
+    title: "Analog inspiration"
+viewer: true
+viewerOptions: "{ title: true }"
+---
+
+Each frame captures a small spark—moments that nudge ideas forward or offer a break from the keyboard. Come back often; I update this gallery whenever something new catches my eye.


### PR DESCRIPTION
## Summary
- add a blog section landing page with introductory copy
- publish three long-form articles covering design, automation, and prototyping themes
- create a gallery page with curated imagery and viewer configuration

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68de7c22dbb48321837b57aa76efd397